### PR TITLE
Add vitest setup and lambert projection tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@deck.gl/geo-layers": "^9.1.12",
@@ -36,6 +37,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/utils/__tests__/lambertProjection.test.ts
+++ b/src/utils/__tests__/lambertProjection.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { lambertProjection } from '../lambertProjection';
+
+describe('lambertProjection', () => {
+  it('projects origin correctly', () => {
+    const [x, y] = lambertProjection(-96, 39);
+    expect(x).toBeCloseTo(0);
+    expect(y).toBeCloseTo(0);
+  });
+
+  it('projects eastern US coordinate', () => {
+    const [x, y] = lambertProjection(-75, 40);
+    expect(x).toBeCloseTo(1.3839378389667728e-7, 10);
+    expect(y).toBeCloseTo(3.298779184497184e-8, 10);
+  });
+
+  it('projects western US coordinate', () => {
+    const [x, y] = lambertProjection(-120, 30);
+    expect(x).toBeCloseTo(-1.8047117723841493e-7, 10);
+    expect(y).toBeCloseTo(-7.261540329341054e-8, 10);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- configure vitest
- add tests for `lambertProjection`
- expose `npm test` script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f780b8fc08333883e431915f5971d