### PR TITLE
Fix default state comment

### DIFF
--- a/src/components/EligibilityEngine.js
+++ b/src/components/EligibilityEngine.js
@@ -20,7 +20,7 @@ export class EligibilityEngine {
 
     // Check state benefits
     if (scope === 'both' || scope === 'state') {
-      const userState = userProfile.state || 'texas'; // Default to Texas
+      const userState = userProfile.state || 'texas'; // Default to 'texas'
       if (this.benefits.state[userState]) {
         this.checkBenefitsGroup(this.benefits.state[userState], userProfile, results);
       }


### PR DESCRIPTION
## Summary
- clarify fallback state comment in `EligibilityEngine.js`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f780a23d88333811b0a3ed27969b8