### PR TITLE
Fix VetNav button class

### DIFF
--- a/components/VetNav.tsx
+++ b/components/VetNav.tsx
@@ -125,7 +125,11 @@ export default function VetNav() {
                       <button
                         key={tab.id}
                         onClick={() => setActiveEducationTab(tab.id)}
-                        className={px-4 py-2 rounded-md transition-all }
+                        className={`px-4 py-2 rounded-md transition-all ${
+                          activeEducationTab === tab.id
+                            ? "bg-white text-blue-700"
+                            : "hover:bg-white/20"
+                        }`}
                       >
                         {tab.label}
                       </button>


### PR DESCRIPTION
## Summary
- fix invalid className syntax in VetNav education tab button
- highlight active tab with basic conditional styles

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7800a5908333b8c8374ace2a7593