### PR TITLE
Fix PDF download filename in export modal

### DIFF
--- a/components/PDFExportModal.tsx
+++ b/components/PDFExportModal.tsx
@@ -25,7 +25,8 @@ export default function PDFExportModal({ userProfile, benefits, isVisible, onClo
       
       const link = document.createElement('a');
       link.href = url;
-      link.download = VetNav-Benefits-Report-.pdf;
+      const timestamp = new Date().toISOString().split('T')[0];
+      link.download = `VetNav-Benefits-Report-${timestamp}.pdf`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);


### PR DESCRIPTION
## Summary
- ensure PDF downloads with a clear filename including the current date

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f77ffa4748333892988bb42ee6e60