### PR TITLE
Add testing setup with Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ pnpm dev
 bun dev
 ```
 
+## Running Tests
+
+Execute the test suite with:
+
+```bash
+npm test
+```
+
+The project uses Jest with React Testing Library. Ensure dependencies are
+installed before running the tests.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+/** @type {import('jest').Config} */
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testEnvironment: 'jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@deck.gl/geo-layers": "^9.1.12",
@@ -36,6 +37,12 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.6",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.2.0",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/components/__tests__/VetNav.test.tsx
+++ b/src/components/__tests__/VetNav.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import VetNav from '../VetNav';
+
+describe('VetNav component', () => {
+  test('renders main menu by default', () => {
+    render(<VetNav />);
+    expect(
+      screen.getByRole('heading', { name: /veterans benefits finder/i })
+    ).toBeInTheDocument();
+  });
+
+  test('navigates to search view and back', () => {
+    render(<VetNav />);
+    const findBtn = screen.getByRole('button', { name: /find benefits/i });
+    fireEvent.click(findBtn);
+    expect(
+      screen.getByRole('heading', { name: /search benefits/i })
+    ).toBeInTheDocument();
+    const backBtn = screen.getByRole('button', { name: /← menu/i });
+    fireEvent.click(backBtn);
+    expect(
+      screen.getByRole('heading', { name: /veterans benefits finder/i })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with React Testing Library
- add initial tests for the `VetNav` component
- provide `npm test` script
- document how to run the tests in `README`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc4b952788333b8229b3599badf03