### PR TITLE
Fix Earth mesh rendering and add missing planet classes

### DIFF
--- a/src/components/planetarySystem/planets/common/Planet.ts
+++ b/src/components/planetarySystem/planets/common/Planet.ts
@@ -1,0 +1,19 @@
+import * as THREE from 'three';
+
+export default class Planet {
+  protected group: THREE.Group;
+  protected radius: number;
+
+  constructor(radius: number) {
+    this.radius = radius;
+    this.group = new THREE.Group();
+  }
+
+  getGroup(): THREE.Group {
+    return this.group;
+  }
+
+  update(_time: number, _sunDirection: THREE.Vector3): void {}
+
+  dispose(): void {}
+}

--- a/src/components/planetarySystem/planets/earth/Earth.ts
+++ b/src/components/planetarySystem/planets/earth/Earth.ts
@@ -1,0 +1,33 @@
+import * as THREE from 'three';
+import Planet from '../common/Planet';
+import { createEarthShaderMaterial, createDefaultEarthUniforms } from './EarthShader';
+
+export class Earth extends Planet {
+  private mesh: THREE.Mesh;
+  private uniforms = createDefaultEarthUniforms();
+
+  constructor(radius: number) {
+    super(radius);
+
+    const geometry = new THREE.SphereGeometry(radius, 64, 64);
+    const material = createEarthShaderMaterial(this.uniforms);
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.group.add(this.mesh);
+  }
+
+  update(time: number, sunDirection: THREE.Vector3): void {
+    this.uniforms.uTime.value = time * 0.001;
+    this.uniforms.uSunDirection.value.copy(sunDirection);
+    this.mesh.rotation.y += 0.001;
+  }
+
+  setAtmosphereIntensity(value: number): void {
+    this.uniforms.uSunIntensity.value = value;
+  }
+
+  override dispose(): void {
+    this.mesh.geometry.dispose();
+    const material = this.mesh.material as THREE.Material;
+    material.dispose();
+  }
+}

--- a/src/components/planetarySystem/planets/jetshome/JetsHome.ts
+++ b/src/components/planetarySystem/planets/jetshome/JetsHome.ts
@@ -1,0 +1,18 @@
+import * as THREE from 'three';
+import Planet from '../common/Planet';
+
+export class JetsHome extends Planet {
+  private mesh: THREE.Mesh;
+
+  constructor(radius: number) {
+    super(radius);
+    const geometry = new THREE.SphereGeometry(radius, 32, 32);
+    const material = new THREE.MeshLambertMaterial({ color: 0x66ccff });
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.group.add(this.mesh);
+  }
+
+  update(time: number): void {
+    this.mesh.rotation.y += 0.0008 * time * 0.001;
+  }
+}

--- a/src/components/planetarySystem/planets/jupiter/Jupiter.ts
+++ b/src/components/planetarySystem/planets/jupiter/Jupiter.ts
@@ -1,0 +1,18 @@
+import * as THREE from 'three';
+import Planet from '../common/Planet';
+
+export class Jupiter extends Planet {
+  private mesh: THREE.Mesh;
+
+  constructor(radius: number) {
+    super(radius);
+    const geometry = new THREE.SphereGeometry(radius, 32, 32);
+    const material = new THREE.MeshLambertMaterial({ color: 0xd2b48c });
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.group.add(this.mesh);
+  }
+
+  update(time: number): void {
+    this.mesh.rotation.y += 0.0005 * time * 0.001;
+  }
+}

--- a/src/components/planetarySystem/planets/mars/Mars.ts
+++ b/src/components/planetarySystem/planets/mars/Mars.ts
@@ -1,0 +1,18 @@
+import * as THREE from 'three';
+import Planet from '../common/Planet';
+
+export class Mars extends Planet {
+  private mesh: THREE.Mesh;
+
+  constructor(radius: number) {
+    super(radius);
+    const geometry = new THREE.SphereGeometry(radius, 32, 32);
+    const material = new THREE.MeshLambertMaterial({ color: 0xb87333 });
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.group.add(this.mesh);
+  }
+
+  update(time: number): void {
+    this.mesh.rotation.y += 0.001 * time * 0.001;
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal `Planet` base class
- create `Earth`, `Mars`, `Jupiter`, and `JetsHome` planet implementations
- use sphere geometry in `Earth` to avoid rendering it as a square

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: several existing project errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fdf3c010483338769c37f074bde9b