### PR TITLE
Fix VetNav education tab styles

### DIFF
--- a/components/VetNav.tsx
+++ b/components/VetNav.tsx
@@ -125,7 +125,11 @@ export default function VetNav() {
                       <button
                         key={tab.id}
                         onClick={() => setActiveEducationTab(tab.id)}
-                        className={px-4 py-2 rounded-md transition-all }
+                        className={`px-4 py-2 rounded-md transition-all ${
+                          activeEducationTab === tab.id
+                            ? 'bg-white/20'
+                            : 'text-blue-200'
+                        }`}
                       >
                         {tab.label}
                       </button>


### PR DESCRIPTION
## Summary
- fix VetNav education tabs className template string

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684074f0b1988333b3dad9384b52e56b