### PR TITLE
Remove redundant Next.js config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;


### PR DESCRIPTION
## Summary
- remove `next.config.ts` since no custom Next.js config is used

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684074f33b98833383c0eeb72b67c42a